### PR TITLE
Renesas mbedcrypto migration

### DIFF
--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -154,10 +154,8 @@ int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
                               void (*free_func)( void * ) );
 #endif /* MBEDTLS_PLATFORM_FREE_MACRO && MBEDTLS_PLATFORM_CALLOC_MACRO */
 #else /* !MBEDTLS_PLATFORM_MEMORY */
-extern void *my_calloc( size_t n, size_t size );
-extern void my_free( void *ptr );
-#define mbedtls_free       my_free
-#define mbedtls_calloc     my_calloc
+#define mbedtls_free       free
+#define mbedtls_calloc     calloc
 #endif /* MBEDTLS_PLATFORM_MEMORY && !MBEDTLS_PLATFORM_{FREE,CALLOC}_MACRO */
 
 /*

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -154,8 +154,10 @@ int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
                               void (*free_func)( void * ) );
 #endif /* MBEDTLS_PLATFORM_FREE_MACRO && MBEDTLS_PLATFORM_CALLOC_MACRO */
 #else /* !MBEDTLS_PLATFORM_MEMORY */
-#define mbedtls_free       free
-#define mbedtls_calloc     calloc
+extern void *my_calloc( size_t n, size_t size );
+extern void my_free( void *ptr );
+#define mbedtls_free       my_free
+#define mbedtls_calloc     my_calloc
 #endif /* MBEDTLS_PLATFORM_MEMORY && !MBEDTLS_PLATFORM_{FREE,CALLOC}_MACRO */
 
 /*

--- a/include/psa/crypto_accel_driver.h
+++ b/include/psa/crypto_accel_driver.h
@@ -38,6 +38,124 @@
 extern "C" {
 #endif
 
+
+/** Import vendor defined key data into a slot.
+ *
+ * `slot->type` must have been set previously.
+ * This function assumes that the slot does not contain any key material yet.
+ * On failure, the slot content is unchanged.
+ *
+ * Persistent storage is not affected.
+ *
+ * \param[in,out] slot  The key slot to import data into.
+ *                      Its `type` field must have previously been set to
+ *                      the desired key type.
+ *                      It must not contain any key material yet.
+ * \param[in] data      Buffer containing the key material to parse and import.
+ * \param data_length   Size of \p data in bytes.
+ * \param write_to_persistent_memory   Specify if the imported key needs to be written to persistent memory.
+ *
+ * \retval PSA_SUCCESS
+ * \retval PSA_ERROR_INVALID_ARGUMENT
+ * \retval PSA_ERROR_NOT_SUPPORTED
+ * \retval PSA_ERROR_INSUFFICIENT_MEMORY
+ * \retval Implementation dependent
+ */
+psa_status_t psa_import_key_into_slot_vendor( psa_key_slot_t *slot,
+                                       const uint8_t *data,
+                                       size_t data_length, 
+                                       bool write_to_persistent_memory);
+
+/**
+ * \brief Generate a vendor defined key or key pair.
+ *
+ * \note    This function has to be defined by the vendor if MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C 
+ *          is defined. Do not use this function directly;
+ *          to generate a key, use psa_generate_key() instead.
+ *
+ * \param[in] slot
+ * \param[in] bits
+ * \param[in] domain_parameters
+ * \param[in] domain_parameters_size
+ *
+ *
+ * \retval #PSA_SUCCESS
+ *         Success.
+ *         If the key is persistent, the key material and the key's metadata
+ *         have been saved to persistent storage.
+ *
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ * \retval Implementation dependent.
+ */
+psa_status_t psa_generate_key_vendor(psa_key_slot_t * slot,
+                                     size_t           bits,
+                                     const uint8_t  * domain_parameters,
+                                     size_t           domain_parameters_size);
+
+/**
+ * \brief Generate symmetric key of vendor defined format.
+ *
+ * \warning This function **can** fail! Callers MUST check the return status
+ *          and MUST NOT use the content of the output buffer if the return
+ *          status is not #PSA_SUCCESS.
+ *
+ * \note    This function has to be defined by the vendor if MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C 
+ *          is defined.
+ *          A weakly linked version is provided by default and returns
+ *          PSA_ERROR_NOT_SUPPORTED. Do not use this function directly;
+ *          to generate a key, use psa_generate_key() instead.
+ *
+ * \param[in] type          Type of symmetric key to be generated.
+ * \param[out] output       Output buffer for the generated data.
+ * \param[out] output_size  Number of bytes to generate and output.
+ *
+ * \retval #PSA_SUCCESS
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ * \retval Implementation dependent
+ */
+psa_status_t psa_generate_symmetric_vendor(psa_key_type_t type, size_t bits, uint8_t * output, size_t output_size);
+
+/** Finalize the creation of a vendor defined key once its key material has been set.
+ *
+ * This entails writing the key to persistent storage.
+ *
+ * This function is to be called only by psa_finish_key_creation(). 
+ *
+ * \param[in,out] slot  Pointer to the slot with key material.
+ *
+ * \retval #PSA_SUCCESS
+ *         The key was successfully created. The handle is now valid.
+ * \return If this function fails, the key slot is an invalid state.
+ */
+psa_status_t psa_finish_key_creation_vendor(psa_key_slot_t *slot);
+
+/**
+ * \brief Perform vendor specific setup for cipher operations.
+ *
+ *
+ * \note    This function has to be defined by the vendor if MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C 
+ *          is defined. 
+ *          A weakly linked version is provided by default and returns
+ *          PSA_ERROR_NOT_SUPPORTED. Do not use this function directly;
+ *          to generate a key, use psa_generate_key() instead.
+ *
+ * \param[in,out] operation     The operation object to set up. It must have
+ *                              been initialized as per the documentation for
+ *                              #psa_cipher_operation_t and not yet in use.
+ * \param handle                Handle to the key to use for the operation.
+ *                              It must remain valid until the operation
+ *                              terminates.
+ * \param alg                   The cipher algorithm to compute
+ *                              (\c PSA_ALG_XXX value such that
+ *                              #PSA_ALG_IS_CIPHER(\p alg) is true).
+ *
+ * \retval #PSA_SUCCESS
+ *         Success.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ * .
+ */
+psa_status_t psa_cipher_setup_vendor(psa_cipher_operation_t * operation, psa_key_handle_t handle, psa_algorithm_t alg, mbedtls_operation_t cipher_operation);
+
 /** \defgroup driver_digest Hardware-Accelerated Message Digests
  *
  * Generation and authentication of Message Digests (aka hashes) must be done

--- a/include/psa/crypto_accel_driver.h
+++ b/include/psa/crypto_accel_driver.h
@@ -154,7 +154,7 @@ psa_status_t psa_finish_key_creation_vendor(psa_key_slot_t *slot);
  * \retval #PSA_ERROR_NOT_SUPPORTED
  * .
  */
-psa_status_t psa_cipher_setup_vendor(psa_cipher_operation_t * operation, psa_key_handle_t handle, psa_algorithm_t alg, mbedtls_operation_t cipher_operation);
+psa_status_t psa_cipher_setup_vendor(psa_cipher_operation_t * operation, psa_key_slot_t * slot, psa_algorithm_t alg, mbedtls_operation_t cipher_operation);
 
 /** \defgroup driver_digest Hardware-Accelerated Message Digests
  *

--- a/include/psa/crypto_accel_driver.h
+++ b/include/psa/crypto_accel_driver.h
@@ -63,7 +63,8 @@ extern "C" {
  */
 psa_status_t psa_import_key_into_slot_vendor( psa_key_slot_t *slot,
                                        const uint8_t *data,
-                                       size_t data_length, 
+                                       size_t data_length,
+									   mbedtls_svc_key_id_t *key,
                                        bool write_to_persistent_memory);
 
 /**

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -649,7 +649,7 @@
  */
 #define PSA_KEY_EXPORT_MAX_SIZE(key_type, key_bits)                     \
     (PSA_KEY_TYPE_IS_UNSTRUCTURED(key_type) ? PSA_BITS_TO_BYTES(key_bits) : \
-     (key_type) == PSA_KEY_TYPE_RSA_KEY_PAIR ? PSA_KEY_EXPORT_RSA_KEY_PAIR_MAX_SIZE(key_bits) : \
+     PSA_KEY_TYPE_IS_RSA_KEY_PAIR (key_type) ? PSA_KEY_EXPORT_RSA_KEY_PAIR_MAX_SIZE(key_bits) : \
      (key_type) == PSA_KEY_TYPE_RSA_PUBLIC_KEY ? PSA_KEY_EXPORT_RSA_PUBLIC_KEY_MAX_SIZE(key_bits) : \
      (key_type) == PSA_KEY_TYPE_DSA_KEY_PAIR ? PSA_KEY_EXPORT_DSA_KEY_PAIR_MAX_SIZE(key_bits) : \
      (key_type) == PSA_KEY_TYPE_DSA_PUBLIC_KEY ? PSA_KEY_EXPORT_DSA_PUBLIC_KEY_MAX_SIZE(key_bits) : \

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -381,11 +381,6 @@
  */
 #define PSA_KEY_TYPE_AES                            ((psa_key_type_t)0x2400)
 
-#if 0
-/** Whether a key type is AES. */
-#define PSA_KEY_TYPE_IS_AES(type) (((type) == PSA_KEY_TYPE_AES) != 0)
-#endif
-
 /** Whether a key type is AES; plaintext or wrapped. */
 #define PSA_KEY_TYPE_IS_AES(type) ((((type) == PSA_KEY_TYPE_AES) != 0) | \
 		(((type) == (PSA_KEY_TYPE_VENDOR_FLAG | PSA_KEY_TYPE_AES)) != 0))
@@ -424,11 +419,6 @@
 #define PSA_KEY_TYPE_RSA_PUBLIC_KEY                 ((psa_key_type_t)0x4001)
 /** RSA key pair (private and public key). */
 #define PSA_KEY_TYPE_RSA_KEY_PAIR                   ((psa_key_type_t)0x7001)
-#if 0
-/** Whether a key type is an RSA key (pair or public-only). */
-#define PSA_KEY_TYPE_IS_RSA(type)                                       \
-    (PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) == PSA_KEY_TYPE_RSA_PUBLIC_KEY)
-#endif
 
 /** Whether a key type is an RSA key pair; standard or vendor. */
 #define PSA_KEY_TYPE_IS_RSA_KEY_PAIR(type)  							\
@@ -459,20 +449,6 @@
  */
 #define PSA_KEY_TYPE_ECC_PUBLIC_KEY(curve)              \
     (PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE | (curve))
-#if 0
-/** Whether a key type is an elliptic curve key (pair or public-only). */
-#define PSA_KEY_TYPE_IS_ECC(type)                                       \
-    ((PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) &                        \
-      ~PSA_KEY_TYPE_ECC_CURVE_MASK) == PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE)
-/** Whether a key type is an elliptic curve key pair. */
-#define PSA_KEY_TYPE_IS_ECC_KEY_PAIR(type)                               \
-    (((type) & ~PSA_KEY_TYPE_ECC_CURVE_MASK) ==                         \
-     PSA_KEY_TYPE_ECC_KEY_PAIR_BASE)
-/** Whether a key type is an elliptic curve public key. */
-#define PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(type)                            \
-    (((type) & ~PSA_KEY_TYPE_ECC_CURVE_MASK) ==                         \
-     PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE)
-#else
 
 /** Whether a key type is an elliptic curve key (pair or public-only). */
 #define PSA_KEY_TYPE_IS_ECC(type)                                           \
@@ -492,7 +468,6 @@
      PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE) ||                                \
 	 (((type) & ~PSA_KEY_TYPE_ECC_CURVE_MASK) ==                         \
      (PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE | PSA_KEY_TYPE_VENDOR_FLAG)))
-#endif
 
 /** Extract the curve from an elliptic curve key type. */
 #define PSA_KEY_TYPE_ECC_GET_FAMILY(type)                        \

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1590,9 +1590,6 @@
 
 #define PSA_KEY_LIFETIME_VENDOR_FLAG ((psa_key_lifetime_t)0x80000000)
 
-#define PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(lifetime) \
-    (((lifetime) & PSA_KEY_LIFETIME_VENDOR_FLAG) != 0)
-
 /** The persistence level of volatile keys.
  *
  * See ::psa_key_persistence_t for more information.

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -382,7 +382,7 @@
 #define PSA_KEY_TYPE_AES                            ((psa_key_type_t)0x2400)
 
 /** Whether a key type is AES; plaintext or wrapped. */
-#define PSA_KEY_TYPE_IS_AES(type) ((((type) == PSA_KEY_TYPE_AES) != 0) | \
+#define PSA_KEY_TYPE_IS_AES(type) ((((type) == PSA_KEY_TYPE_AES) != 0) || \
 		(((type) == (PSA_KEY_TYPE_VENDOR_FLAG | PSA_KEY_TYPE_AES)) != 0))
 
 /** Key for a cipher or MAC algorithm based on DES or 3DES (Triple-DES).
@@ -428,7 +428,7 @@
 
 /** Whether a key type is an RSA key (pair or public-only) standard or vendor. */
 #define PSA_KEY_TYPE_IS_RSA(type)                                       \
-    ((PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) == PSA_KEY_TYPE_RSA_PUBLIC_KEY) | \
+    ((PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) == PSA_KEY_TYPE_RSA_PUBLIC_KEY) || \
 	 (PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) == (PSA_KEY_TYPE_RSA_PUBLIC_KEY | PSA_KEY_TYPE_VENDOR_FLAG)))
 
 
@@ -1598,8 +1598,6 @@
  */
 
 #define PSA_KEY_LIFETIME_PERSISTENT             ((psa_key_lifetime_t)0x00000001)
-#define PSA_KEY_LIFETIME_PERSISTENT_FLAG        ((psa_key_lifetime_t)PSA_KEY_LIFETIME_PERSISTENT)
-//#define PSA_KEY_LIFETIME_IS_VOLATILE(lifetime)  (((lifetime) & PSA_KEY_LIFETIME_PERSISTENT_FLAG) == 0)
 
 #define PSA_KEY_LIFETIME_IS_PERSISTENT(lifetime) \
     (((lifetime) & PSA_KEY_LIFETIME_PERSISTENT) != 0)

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -381,8 +381,14 @@
  */
 #define PSA_KEY_TYPE_AES                            ((psa_key_type_t)0x2400)
 
+#if 0
 /** Whether a key type is AES. */
 #define PSA_KEY_TYPE_IS_AES(type) (((type) == PSA_KEY_TYPE_AES) != 0)
+#endif
+
+/** Whether a key type is AES; plaintext or wrapped. */
+#define PSA_KEY_TYPE_IS_AES(type) ((((type) == PSA_KEY_TYPE_AES) != 0) | \
+		(((type) == (PSA_KEY_TYPE_VENDOR_FLAG | PSA_KEY_TYPE_AES)) != 0))
 
 /** Key for a cipher or MAC algorithm based on DES or 3DES (Triple-DES).
  *

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -418,9 +418,23 @@
 #define PSA_KEY_TYPE_RSA_PUBLIC_KEY                 ((psa_key_type_t)0x4001)
 /** RSA key pair (private and public key). */
 #define PSA_KEY_TYPE_RSA_KEY_PAIR                   ((psa_key_type_t)0x7001)
+#if 0
 /** Whether a key type is an RSA key (pair or public-only). */
 #define PSA_KEY_TYPE_IS_RSA(type)                                       \
     (PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) == PSA_KEY_TYPE_RSA_PUBLIC_KEY)
+#endif
+
+/** Whether a key type is an RSA key pair; standard or vendor. */
+#define PSA_KEY_TYPE_IS_RSA_KEY_PAIR(type)  							\
+	((type == PSA_KEY_TYPE_RSA_KEY_PAIR) | \
+	 (type == (PSA_KEY_TYPE_RSA_KEY_PAIR | PSA_KEY_TYPE_VENDOR_FLAG)))
+
+
+/** Whether a key type is an RSA key (pair or public-only) standard or vendor. */
+#define PSA_KEY_TYPE_IS_RSA(type)                                       \
+    ((PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) == PSA_KEY_TYPE_RSA_PUBLIC_KEY) | \
+	 (PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) == (PSA_KEY_TYPE_RSA_PUBLIC_KEY | PSA_KEY_TYPE_VENDOR_FLAG)))
+
 
 #define PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE            ((psa_key_type_t)0x4100)
 #define PSA_KEY_TYPE_ECC_KEY_PAIR_BASE              ((psa_key_type_t)0x7100)

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -381,6 +381,9 @@
  */
 #define PSA_KEY_TYPE_AES                            ((psa_key_type_t)0x2400)
 
+/** Whether a key type is AES. */
+#define PSA_KEY_TYPE_IS_AES(type) (((type) == PSA_KEY_TYPE_AES) != 0)
+
 /** Key for a cipher or MAC algorithm based on DES or 3DES (Triple-DES).
  *
  * The size of the key can be 8 bytes (single DES), 16 bytes (2-key 3DES) or
@@ -1577,7 +1580,18 @@
  * by other lifetime values as implementation-specific extensions.
  * See ::psa_key_lifetime_t for more information.
  */
+
 #define PSA_KEY_LIFETIME_PERSISTENT             ((psa_key_lifetime_t)0x00000001)
+#define PSA_KEY_LIFETIME_PERSISTENT_FLAG        ((psa_key_lifetime_t)PSA_KEY_LIFETIME_PERSISTENT)
+//#define PSA_KEY_LIFETIME_IS_VOLATILE(lifetime)  (((lifetime) & PSA_KEY_LIFETIME_PERSISTENT_FLAG) == 0)
+
+#define PSA_KEY_LIFETIME_IS_PERSISTENT(lifetime) \
+    (((lifetime) & PSA_KEY_LIFETIME_PERSISTENT) != 0)
+
+#define PSA_KEY_LIFETIME_VENDOR_FLAG ((psa_key_lifetime_t)0x80000000)
+
+#define PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(lifetime) \
+    (((lifetime) & PSA_KEY_LIFETIME_VENDOR_FLAG) != 0)
 
 /** The persistence level of volatile keys.
  *

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -426,7 +426,7 @@
 
 /** Whether a key type is an RSA key pair; standard or vendor. */
 #define PSA_KEY_TYPE_IS_RSA_KEY_PAIR(type)  							\
-	((type == PSA_KEY_TYPE_RSA_KEY_PAIR) | \
+	((type == PSA_KEY_TYPE_RSA_KEY_PAIR) || \
 	 (type == (PSA_KEY_TYPE_RSA_KEY_PAIR | PSA_KEY_TYPE_VENDOR_FLAG)))
 
 
@@ -453,7 +453,7 @@
  */
 #define PSA_KEY_TYPE_ECC_PUBLIC_KEY(curve)              \
     (PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE | (curve))
-
+#if 0
 /** Whether a key type is an elliptic curve key (pair or public-only). */
 #define PSA_KEY_TYPE_IS_ECC(type)                                       \
     ((PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) &                        \
@@ -466,6 +466,27 @@
 #define PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(type)                            \
     (((type) & ~PSA_KEY_TYPE_ECC_CURVE_MASK) ==                         \
      PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE)
+#else
+
+/** Whether a key type is an elliptic curve key (pair or public-only). */
+#define PSA_KEY_TYPE_IS_ECC(type)                                           \
+    (((PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) &                          \
+      ~PSA_KEY_TYPE_ECC_CURVE_MASK) == PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE) || \
+	  ((PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(type) &                         \
+      ~PSA_KEY_TYPE_ECC_CURVE_MASK) == (PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE | PSA_KEY_TYPE_VENDOR_FLAG)))
+/** Whether a key type is an elliptic curve key pair. */
+#define PSA_KEY_TYPE_IS_ECC_KEY_PAIR(type)                               \
+    ((((type) & ~PSA_KEY_TYPE_ECC_CURVE_MASK) ==                         \
+     PSA_KEY_TYPE_ECC_KEY_PAIR_BASE) ||                                  \
+	 (((type) & ~PSA_KEY_TYPE_ECC_CURVE_MASK) ==                         \
+     (PSA_KEY_TYPE_ECC_KEY_PAIR_BASE | PSA_KEY_TYPE_VENDOR_FLAG)))
+/** Whether a key type is an elliptic curve public key. */
+#define PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(type)                             \
+    ((((type) & ~PSA_KEY_TYPE_ECC_CURVE_MASK) ==                         \
+     PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE) ||                                \
+	 (((type) & ~PSA_KEY_TYPE_ECC_CURVE_MASK) ==                         \
+     (PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE | PSA_KEY_TYPE_VENDOR_FLAG)))
+#endif
 
 /** Extract the curve from an elliptic curve key type. */
 #define PSA_KEY_TYPE_ECC_GET_FAMILY(type)                        \

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -24,7 +24,7 @@
 
 #include "common.h"
 
-#if defined(MBEDTLS_CTR_DRBG_C)
+#if !defined(MBEDTLS_CTR_DRBG_C_ALT)
 
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/platform_util.h"

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -34,6 +34,8 @@
 
 #include <string.h>
 
+#if !defined(MBEDTLS_ECDH_ALT)
+
 /* Parameter validation macros based on platform_util.h */
 #define ECDH_VALIDATE_RET( cond )    \
     MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_ECP_BAD_INPUT_DATA )
@@ -726,4 +728,5 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
 #endif
 }
 
+#endif /*!MBEDTLS_ECDH_ALT */
 #endif /* MBEDTLS_ECDH_C */

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -835,6 +835,15 @@ static psa_status_t psa_load_ecp_representation( psa_key_type_t type,
     }
 
     *p_ecp = ecp;
+#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
+    if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(type))
+    {
+        /* Setup the vendor context flag */
+    	(*p_ecp)->grp.vendor_ctx = (bool *) true;
+        
+    }
+#endif /* MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C */
+
 exit:
     if( status != PSA_SUCCESS )
     {
@@ -860,7 +869,7 @@ exit:
  * \param[in] data_size     The length of the buffer to export to
  * \param[out] data_length  The amount of bytes written to \p data
  */
-static psa_status_t psa_export_ecp_key( psa_key_type_t type,
+psa_status_t psa_export_ecp_key( psa_key_type_t type,
                                         mbedtls_ecp_keypair *ecp,
                                         uint8_t *data,
                                         size_t data_size,
@@ -916,7 +925,7 @@ static psa_status_t psa_export_ecp_key( psa_key_type_t type,
  * \param[in] data          The buffer containing the import representation
  * \param[in] data_length   The amount of bytes in \p data
  */
-static psa_status_t psa_import_ecp_key( psa_key_slot_t *slot,
+psa_status_t psa_import_ecp_key( psa_key_slot_t *slot,
                                         const uint8_t *data,
                                         size_t data_length )
 {

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2146,7 +2146,7 @@ static psa_status_t psa_start_key_creation(
     (void) driver;
 
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
-    if( PSA_KEY_LIFETIME_IS_PERSISTENT( slot->attr.lifetime ) )
+    if( ! PSA_KEY_LIFETIME_IS_VOLATILE( slot->attr.lifetime ) )
     {
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
         if( driver != NULL )

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -589,7 +589,7 @@ static psa_status_t psa_load_rsa_representation( psa_key_type_t type,
     *p_rsa = mbedtls_pk_rsa( ctx );
     ctx.pk_info = NULL;
 
-#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
+#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C) && defined(MBEDTLS_RSA_ALT)
     if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(type))
     {
         /* Setup the vendor context flag */
@@ -792,7 +792,7 @@ static psa_status_t psa_load_ecp_representation( psa_key_type_t type,
     mbedtls_ecp_keypair_init( ecp );
 
     /* Load the group. */
-#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
+#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C) && defined(MBEDTLS_ECP_ALT)
     if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(type))
     {
     	grp_id = mbedtls_ecc_group_of_psa( PSA_KEY_TYPE_ECC_GET_FAMILY( type ), PSA_ECC_BYTES_VENDOR_RAW(curve_size) );
@@ -843,7 +843,7 @@ static psa_status_t psa_load_ecp_representation( psa_key_type_t type,
     }
 
     *p_ecp = ecp;
-#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
+#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C) && defined(MBEDTLS_ECP_ALT)
     if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(type))
     {
         /* Setup the vendor context flag */
@@ -912,7 +912,7 @@ psa_status_t psa_export_ecp_key( psa_key_type_t type,
     else
     {
     	uint32_t private_key_bytes = 0;
-#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
+#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C) && defined(MBEDTLS_ECP_ALT)
 		if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(type))
 		{
 			/* Setup the vendor private key size. The

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2349,7 +2349,7 @@ psa_status_t psa_import_key( const psa_key_attributes_t *attributes,
 #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
     if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(slot->attr.type))
     {
-        status = psa_import_key_into_slot_vendor( slot, data, data_length, true);
+        status = psa_import_key_into_slot_vendor( slot, data, data_length, key, true);
             goto exit;
     }
     else
@@ -3951,7 +3951,7 @@ psa_status_t psa_sign_hash( mbedtls_svc_key_id_t key,
     /* If the operation was not supported by any accelerator, try fallback. */
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_SIGN) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PSS)
-    if( slot->attr.type == PSA_KEY_TYPE_RSA_KEY_PAIR )
+    if( PSA_KEY_TYPE_IS_RSA_KEY_PAIR (slot->attr.type) )
     {
         mbedtls_rsa_context *rsa = NULL;
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3361,7 +3361,7 @@ static psa_status_t psa_mac_setup( psa_mac_operation_t *operation,
     {
         const mbedtls_cipher_info_t *cipher_info =
             mbedtls_cipher_info_from_psa( full_length_alg,
-                                          slot->attr.type, key_bits, NULL );
+                                          (slot->attr.type & ~PSA_KEY_TYPE_VENDOR_FLAG), key_bits, NULL );
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
         if( cipher_info == NULL )
         {
@@ -4955,6 +4955,7 @@ static psa_status_t psa_aead_setup( aead_operation_t *operation,
     psa_status_t status;
     size_t key_bits;
     mbedtls_cipher_id_t cipher_id;
+    psa_key_type_t temp_keytype = 0;
 
     status = psa_get_and_lock_transparent_key_slot_with_policy(
                  key, &operation->slot, usage, alg );
@@ -4975,11 +4976,16 @@ static psa_status_t psa_aead_setup( aead_operation_t *operation,
         {
             return status;
         }
+
+        temp_keytype = (psa_key_type_t)(operation->slot->attr.type & ~PSA_KEY_TYPE_VENDOR_FLAG);
     }
 #endif /* MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C */
-
+        else
+        {
+        	temp_keytype = (psa_key_type_t)(operation->slot->attr.type);
+        }
     operation->cipher_info =
-        mbedtls_cipher_info_from_psa( alg, operation->slot->attr.type, key_bits,
+        mbedtls_cipher_info_from_psa( alg,temp_keytype, key_bits,
                                       &cipher_id );
     if( operation->cipher_info == NULL )
     {

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4965,7 +4965,7 @@ static psa_status_t psa_aead_setup( aead_operation_t *operation,
     key_bits = psa_get_key_slot_bits( operation->slot );
 
 #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
-        if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(operation->slot->attr.type))
+    if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(operation->slot->attr.type))
     {
         /* The mbedcrypto implementation obtains the list of methods based on the keybit size.
          * Since the wrapped keybit size does not correspond to the raw key size i.e the
@@ -4979,11 +4979,11 @@ static psa_status_t psa_aead_setup( aead_operation_t *operation,
 
         temp_keytype = (psa_key_type_t)(operation->slot->attr.type & ~PSA_KEY_TYPE_VENDOR_FLAG);
     }
+    else
 #endif /* MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C */
-        else
-        {
-        	temp_keytype = (psa_key_type_t)(operation->slot->attr.type);
-        }
+     {
+        temp_keytype = (psa_key_type_t)(operation->slot->attr.type);
+    }
     operation->cipher_info =
         mbedtls_cipher_info_from_psa( alg,temp_keytype, key_bits,
                                       &cipher_id );

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2126,7 +2126,7 @@ static psa_status_t psa_start_key_creation(
         else
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
-    if (PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(slot->attr.lifetime))
+    if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(slot->attr.type))
     {
         status = psa_finish_key_creation_vendor( slot );
     }
@@ -2338,7 +2338,7 @@ psa_status_t psa_import_key( const psa_key_attributes_t *attributes,
     else
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
-    if (PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(slot->attr.lifetime))
+    if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(slot->attr.type))
     {
         status = psa_import_key_into_slot_vendor( slot, data, data_length, true);
             goto exit;
@@ -4418,9 +4418,9 @@ static psa_status_t psa_cipher_setup( psa_cipher_operation_t *operation,
 
     key_bits = psa_get_key_slot_bits( slot );
     #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
-    if (PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(slot->attr.lifetime))
+    if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(slot->attr.type))
     {
-        status = psa_cipher_setup_vendor(operation, handle, alg, cipher_operation); 
+        status = psa_cipher_setup_vendor(operation, slot, alg, cipher_operation); 
         goto exit;
     }
     #endif /* MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C */
@@ -4924,7 +4924,7 @@ static psa_status_t psa_aead_setup( aead_operation_t *operation,
     key_bits = psa_get_key_slot_bits( operation->slot );
 
 #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
-    if (PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(operation->slot->attr.lifetime))
+        if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(operation->slot->attr.type))
     {
         /* The mbedcrypto implementation obtains the list of methods based on the keybit size.
          * Since the wrapped keybit size does not correspond to the raw key size i.e the
@@ -6592,7 +6592,7 @@ psa_status_t psa_generate_key( const psa_key_attributes_t *attributes,
         psa_key_lifetime_is_external( attributes->core.lifetime ) )
         goto exit;
 #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
-    if (PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(slot->attr.lifetime))
+    if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(slot->attr.type))
     {
         status = psa_generate_key_vendor(slot, attributes->core.bits,
             attributes->domain_parameters, attributes->domain_parameters_size);

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -160,7 +160,6 @@ static inline void psa_key_slot_set_bits_in_flags( psa_key_slot_t *slot,
 static inline void psa_key_slot_clear_bits( psa_key_slot_t *slot,
                                             uint16_t mask )
 {
-    //slot->attr.flags &= ~mask;
     slot->attr.flags = (psa_key_attributes_flag_t) (slot->attr.flags & (~mask)); 
 }
 

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -137,7 +137,7 @@ static inline void psa_key_slot_set_flags( psa_key_slot_t *slot,
                                            uint16_t mask,
                                            uint16_t value )
 {
-    slot->attr.flags = ( ( ~mask & slot->attr.flags ) |
+    slot->attr.flags = (psa_key_attributes_flag_t) ( ( ~mask & slot->attr.flags ) |
                               ( mask & value ) );
 }
 
@@ -160,7 +160,8 @@ static inline void psa_key_slot_set_bits_in_flags( psa_key_slot_t *slot,
 static inline void psa_key_slot_clear_bits( psa_key_slot_t *slot,
                                             uint16_t mask )
 {
-    slot->attr.flags &= ~mask;
+    //slot->attr.flags &= ~mask;
+    slot->attr.flags = (psa_key_attributes_flag_t) (slot->attr.flags & (~mask)); 
 }
 
 /** Completely wipe a slot in memory, including its policy.

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -262,6 +262,14 @@ static psa_status_t psa_load_persistent_key_into_slot( psa_key_slot_t *slot )
     }
     else
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
+#if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
+    if (PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(slot->attr.lifetime))
+    {
+        status = psa_import_key_into_slot_vendor( slot, key_data, key_data_length, false);
+            goto exit;
+    }
+    else
+#endif /* MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C */
     {
         status = psa_copy_key_material_into_slot( slot, key_data, key_data_length );
         if( status != PSA_SUCCESS )

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -263,7 +263,7 @@ static psa_status_t psa_load_persistent_key_into_slot( psa_key_slot_t *slot )
     else
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
-    if (PSA_KEY_LIFETIME_IS_VENDOR_DEFINED(slot->attr.lifetime))
+    if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(slot->attr.type))
     {
         status = psa_import_key_into_slot_vendor( slot, key_data, key_data_length, false);
             goto exit;

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -265,7 +265,7 @@ static psa_status_t psa_load_persistent_key_into_slot( psa_key_slot_t *slot )
 #if defined (MBEDTLS_PSA_CRYPTO_ACCEL_DRV_C)
     if (PSA_KEY_TYPE_IS_VENDOR_DEFINED(slot->attr.type))
     {
-        status = psa_import_key_into_slot_vendor( slot, key_data, key_data_length, false);
+        status = psa_import_key_into_slot_vendor( slot, key_data, key_data_length, NULL, false);
             goto exit;
     }
     else


### PR DESCRIPTION
Notes:
## Description
Add support for Renesas vendor type keys. 


## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
