### PR TITLE
Fix IAR compiler endianness detection in alignment.h

### DIFF
--- a/ChangeLog.d/fix_iar_endianess.txt
+++ b/ChangeLog.d/fix_iar_endianess.txt
@@ -1,0 +1,2 @@
+Bugfix
+ * Fix incorrect big-endian detection for the IAR compiler in library/alignment.h which caused big-endian targets to be misidentified.

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -383,10 +383,10 @@ static inline uint64_t mbedtls_bswap64(uint64_t x)
 
 #if !defined(__BYTE_ORDER__)
 
-#if defined(__LITTLE_ENDIAN__)
+#if defined(__LITTLE_ENDIAN__) && (__LITTLE_ENDIAN__ == 1)
 /* IAR defines __xxx_ENDIAN__, but not __BYTE_ORDER__ */
 #define MBEDTLS_IS_BIG_ENDIAN 0
-#elif defined(__BIG_ENDIAN__)
+#elif defined(__BIG_ENDIAN__) && (__BIG_ENDIAN__ == 1)
 #define MBEDTLS_IS_BIG_ENDIAN 1
 #else
 static const uint16_t mbedtls_byte_order_detector = { 0x100 };


### PR DESCRIPTION
## Description

> This PR fixes a critical bug where the IAR compiler always triggers the Little-Endian code path, even when compiling for Big-Endian CPU. Fix https://github.com/Mbed-TLS/mbedtls/issues/10381
> The IAR C/C++ compiler always defines both `__LITTLE_ENDIAN__` and `__BIG_ENDIAN__` macros internally, assigning '1' to the active endianness and '0' to the inactive one. The previous check `defined(__BIG_ENDIAN__)` always evaluated to true on IAR. This commit updates the check to verify the actual value: `(__BIG_ENDIAN__ == 1)`.
> <img width="627" height="94" alt="image" src="https://github.com/user-attachments/assets/af07401f-62ea-4990-ab5a-a951b0ee4b8f" />
>### References from IAR Development Guide for several MCU families
>[1] ARM: https://wwwfiles.iar.com/arm/webic/doc/EWARM_DevelopmentGuide.ENU.pdf - p.494
>[2] Renesas RX: https://wwwfiles.iar.com/RX/webic/doc/EWRX_DevelopmentGuide.ENU.pdf - p. 428
> [3] Renesas RL78: https://wwwfiles.iar.com/rl78/EWRL78_DevelopmentGuide.ENU.pdf -p.389
> [4] STM8: https://wwwfiles.iar.com/stm8/guides/EWSTM8_DevelopmentGuide.pdf - p.334


## Status
**READY**

## Upstream MbedTLS Issue & PR
https://github.com/Mbed-TLS/mbedtls/issues/10381
https://github.com/Mbed-TLS/mbedtls/pull/10840
